### PR TITLE
Add token auth and require login for all endpoints

### DIFF
--- a/CS3450_backend/settings.py
+++ b/CS3450_backend/settings.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = []
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
+    "rest_framework.authtoken",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
@@ -83,6 +84,12 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "CS3450_backend.wsgi.application"
 
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+}
 
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases


### PR DESCRIPTION
- changed the method of authentication 
- Added requirement on all views to be logged in (must have valid token) (except login and sign up)
- This change requires all requests to the api have the Authentication header set which I have done in a pr on the front end. 
- You may need to run migrate so just run `python manage.py migrate` once you've got this locally just to be sure.